### PR TITLE
Feat/like

### DIFF
--- a/src/main/java/com/newspeed/sixteenflow/domain/like/controller/PostLikeController.java
+++ b/src/main/java/com/newspeed/sixteenflow/domain/like/controller/PostLikeController.java
@@ -1,0 +1,37 @@
+package com.newspeed.sixteenflow.domain.like.controller;
+
+import com.newspeed.sixteenflow.domain.like.dto.PostLikeRequestDto;
+import com.newspeed.sixteenflow.domain.like.dto.PostLikeResponseDto;
+import com.newspeed.sixteenflow.domain.like.service.PostLikeService;
+import com.newspeed.sixteenflow.domain.post.entity.Post;
+import com.newspeed.sixteenflow.global.common.ApiResponse;
+import com.newspeed.sixteenflow.global.response.success.LikeSuccess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    //좋아요기능
+    @PostMapping("/{postId}/likes")
+    public ResponseEntity<ApiResponse<PostLikeResponseDto>> toggleLike(
+            @PathVariable Long postId,
+            @RequestBody PostLikeRequestDto postLikeRequest
+    ){
+
+        PostLikeResponseDto postresponse = postLikeService.toggleLike(postLikeRequest.getMemberId(), postId);
+
+        if (postresponse.isLike()) {
+            return ApiResponse.status(LikeSuccess.POST_LIKE_SUCCESS).body(postresponse);
+        } else {
+            return ApiResponse.status(LikeSuccess.POST_LIKE_CANCEL).body(postresponse);
+        }
+    }
+
+    //좋아요 전체 조회기능 구현 필요
+}

--- a/src/main/java/com/newspeed/sixteenflow/domain/like/dto/PostLikeRequestDto.java
+++ b/src/main/java/com/newspeed/sixteenflow/domain/like/dto/PostLikeRequestDto.java
@@ -1,0 +1,8 @@
+package com.newspeed.sixteenflow.domain.like.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostLikeRequestDto {
+    private Long memberId;
+}

--- a/src/main/java/com/newspeed/sixteenflow/domain/like/dto/PostLikeResponseDto.java
+++ b/src/main/java/com/newspeed/sixteenflow/domain/like/dto/PostLikeResponseDto.java
@@ -1,0 +1,16 @@
+package com.newspeed.sixteenflow.domain.like.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostLikeResponseDto {
+    private Long postId;
+    private int likePostCount;
+    private boolean like; // 현재 좋아요 상태 (toggle용)
+
+    public PostLikeResponseDto(Long postId, int likePostCount, boolean like) {
+        this.postId = postId;
+        this.likePostCount = likePostCount; // 좋아요 수
+        this.like = like; //좋아요 상태를 한번 더 알려줌 (없어도 됨)
+    }
+}

--- a/src/main/java/com/newspeed/sixteenflow/domain/like/entity/PostLike.java
+++ b/src/main/java/com/newspeed/sixteenflow/domain/like/entity/PostLike.java
@@ -1,0 +1,40 @@
+package com.newspeed.sixteenflow.domain.like.entity;
+
+import com.newspeed.sixteenflow.domain.member.entity.Member;
+import com.newspeed.sixteenflow.domain.post.entity.Post;
+import com.newspeed.sixteenflow.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Getter;
+
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@Table(name = "post_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"post_id", "member_id"}) // 혹시 모를 중복 좋아요 방지
+})
+public class PostLike extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public static PostLike of(Post post, Member member) {
+        PostLike like = new PostLike();
+        like.post = post;
+        like.member = member;
+        return like;
+    }
+}
+
+

--- a/src/main/java/com/newspeed/sixteenflow/domain/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/newspeed/sixteenflow/domain/like/repository/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package com.newspeed.sixteenflow.domain.like.repository;
+
+import com.newspeed.sixteenflow.domain.like.entity.PostLike;
+import com.newspeed.sixteenflow.domain.member.entity.Member;
+import com.newspeed.sixteenflow.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByMemberAndPost(Member member, Post post);
+    int countByPostId(Long postId);
+
+}

--- a/src/main/java/com/newspeed/sixteenflow/domain/like/service/PostLikeService.java
+++ b/src/main/java/com/newspeed/sixteenflow/domain/like/service/PostLikeService.java
@@ -1,0 +1,51 @@
+package com.newspeed.sixteenflow.domain.like.service;
+
+import com.newspeed.sixteenflow.domain.like.dto.PostLikeResponseDto;
+import com.newspeed.sixteenflow.domain.like.entity.PostLike;
+import com.newspeed.sixteenflow.domain.like.repository.PostLikeRepository;
+import com.newspeed.sixteenflow.domain.member.entity.Member;
+import com.newspeed.sixteenflow.domain.member.repository.MemberRepository;
+import com.newspeed.sixteenflow.domain.post.entity.Post;
+import com.newspeed.sixteenflow.domain.post.repository.PostRepository;
+import com.newspeed.sixteenflow.global.exception.like.PostLikeException;
+import com.newspeed.sixteenflow.global.response.error.LikeError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final MemberRepository memberRepository; //memberId
+    private final PostRepository postRepository; //postId
+
+    //좋아요 누르기 (toggle)/ 취소 == HardDelete, 만일 existing되어 있는경우는 좋아요가 눌러진 상태
+    public PostLikeResponseDto toggleLike(Long memberId, Long postId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostLikeException());
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PostLikeException());
+
+
+        Optional<PostLike> isExisting = postLikeRepository.findByMemberAndPost(member, post);
+
+        boolean like; // 좋아요 필요가 있나? 명시적? 한번 확인 할것(DB에는 안들어가지 않는가)
+        if (isExisting.isPresent()) { //이미 좋아요인 경우 취소 존재하므로 isPresent가 true로 나옴.
+            postLikeRepository.delete(isExisting.get());
+            like = false;
+
+        } else { //좋아요를 하지 않은 경우
+            PostLike postLike = PostLike.of(post, member);
+            postLikeRepository.save(postLike); //DB에 저장
+            like = true; //좋아요 상태를 만들어 줌.
+        }
+
+        int likeCount = postLikeRepository.countByPostId(postId);
+        return new PostLikeResponseDto(postId, likeCount, like);
+
+    }
+}

--- a/src/main/java/com/newspeed/sixteenflow/global/exception/like/PostLikeException.java
+++ b/src/main/java/com/newspeed/sixteenflow/global/exception/like/PostLikeException.java
@@ -1,0 +1,15 @@
+package com.newspeed.sixteenflow.global.exception.like;
+
+import com.newspeed.sixteenflow.global.common.BaseCode;
+import com.newspeed.sixteenflow.global.exception.BaseException;
+import com.newspeed.sixteenflow.global.response.error.LikeError;
+
+public class PostLikeException extends BaseException {
+    @Override
+    public BaseCode getErrorCode() {
+        return LikeError.POST_ERROR;
+    }
+
+
+
+}

--- a/src/main/java/com/newspeed/sixteenflow/global/response/error/LikeError.java
+++ b/src/main/java/com/newspeed/sixteenflow/global/response/error/LikeError.java
@@ -1,0 +1,30 @@
+package com.newspeed.sixteenflow.global.response.error;
+
+import com.newspeed.sixteenflow.global.common.BaseCode;
+import org.springframework.http.HttpStatus;
+
+public enum LikeError implements BaseCode {
+    //MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    COMMENT_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    POST_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    LikeError(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/com/newspeed/sixteenflow/global/response/success/LikeSuccess.java
+++ b/src/main/java/com/newspeed/sixteenflow/global/response/success/LikeSuccess.java
@@ -1,0 +1,30 @@
+package com.newspeed.sixteenflow.global.response.success;
+
+import com.newspeed.sixteenflow.global.common.BaseCode;
+import org.springframework.http.HttpStatus;
+
+public enum LikeSuccess implements BaseCode {
+    POST_LIKE_SUCCESS(HttpStatus.CREATED, "게시글 좋아요 성공"),
+    POST_LIKE_CANCEL(HttpStatus.OK, "게시글 좋아요 취소"),
+    COMMENT_LIKE_SUCCESS(HttpStatus.CREATED, "댓글 좋아요 성공"),
+    COMMENT_LIKE_CANCEL(HttpStatus.OK, "댓글 좋아요 취소");
+
+
+    private final HttpStatus status;
+    private final String message;
+
+    LikeSuccess(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
게시글 좋아요 기능을 구현하였습니다.

- 게시글에 대해 좋아요/취소(toggle) 기능을 구현하였습니다.
- 현재는 JWT 인증/인가 없이 memberId를 요청 body에 포함시켜 처리하고 있습니다.
- 추후 JWT에 대해서 더 공부 후, 인증된 사용자 정보로 동작하도록 수정할 예정입니다.
- 이상한 부분 있으시면 언제든지 말씀부탁드립니다.